### PR TITLE
Update FreetComponent.vue

### DIFF
--- a/client/components/Freet/FreetComponent.vue
+++ b/client/components/Freet/FreetComponent.vue
@@ -337,7 +337,7 @@ export default {
           const res = await r.json();
           // console.log("res is:", res);
           // console.log("res.error is:", res.error);
-          // throw new Error(res.error);
+          throw new Error(res.error.downvoteNotFound);
         } else if (options.method === "GET") {
           // Like exists so we can show the user liked this
           this.downvoted = true;
@@ -345,14 +345,13 @@ export default {
 
         params.callback();
       } catch (e) {
-        console.log("e is", e.message);
-        // if (e.likeFound){
-        //   this.$set(this.alerts, e.likeFound, 'error');
-        // } else if(e.likeNotFound) {
-        //   this.$set(this.alerts, e.likeNotFound, 'error');
-        // } else{
-        //   this.$set(this.alerts, e, 'error');
-        // }
+        if (e.likeFound){
+          this.$set(this.alerts, e.likeFound, 'error');
+        } else if(e.likeNotFound) {
+          this.$set(this.alerts, e.likeNotFound, 'error');
+        } else{
+          this.$set(this.alerts, e, 'error');
+        }
         // this.$set(this.alerts, e, 'error');
         // setTimeout(() => this.$delete(this.alerts, e), 3000);
       }


### PR DESCRIPTION
Hi Ben,

I'm 6.1040 TA from today's studio hour.

I looked into printing errors, and it says that JS Error object cannot be naively stringified using JSON. This - along with ways to deal with this problem - are described in detail in this link: [Is it not possible to stringify an Error using JSON.stringify?](https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify).
So I think that is why JSON.stringify(e) was printing an empty object {}, although it is not actually empty.

So the reason why `throw new Error(res.error);` was not working is because your response has a different structure from the ones in other parts of the code.
In other parts of the code, the `error` field directly contains the string message, but your `error` field contains another nested field `downvoteNotFound`
So that is why you need to take it out.
Thus, it should be `throw new Error(res.error.downvoteNotFound);` instead.
Or you can change the server-side code to remove the nested field.

I created [a pull request](https://github.com/bengao01/fritter-frontend/pull/1) reflecting these changes.

Hope this helps!
Thanks